### PR TITLE
Handle mismatched version lengths more correctly.

### DIFF
--- a/gsuite-device-update-notifier/main.js
+++ b/gsuite-device-update-notifier/main.js
@@ -95,8 +95,10 @@ function compareOSVersions(v1, v2) {
     }
   }
 
-  if (v1.length != v2.length) {
+  if (v1.length < v2.length) {
     return -1;
+  } else if (v1.length > v2.length) {
+    return 1;
   }
 
   return 0;


### PR DESCRIPTION
Consider 13.1.2 vs 13.1; this now handles either v1 or v2 being shorter.