### PR TITLE
Use a set to prevent ordering issues in gsuite-saml-cognito module

### DIFF
--- a/terraform-modules/gsuite-saml-cognito/main.tf
+++ b/terraform-modules/gsuite-saml-cognito/main.tf
@@ -23,7 +23,7 @@ resource "aws_cognito_user_pool_client" "gsuite_saml" {
   name                         = var.name
   user_pool_id                 = aws_cognito_user_pool.gsuite_saml.id
   supported_identity_providers = [aws_cognito_identity_provider.gsuite_saml.provider_name]
-  callback_urls = concat(
+  callback_urls = toset(concat(
     [
       "https://${var.dns_name}",
       "https://${var.dns_name}/oauth2/idpresponse",
@@ -36,7 +36,7 @@ resource "aws_cognito_user_pool_client" "gsuite_saml" {
         "https://${dns_name}/saml2/idpresponse",
       ]
     ]))
-  )
+  ))
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["openid"]


### PR DESCRIPTION
When testing this module I noticed that  `callback_urls` is always generating a planned change due to ordering changes
```
      ~ callback_urls                        = [
          - "https://a.example.com/",
          - "https://a.example.com/oauth2/idpresponse",
          - "https://a.example.com/saml2/idpresponse",
            "https://b.example.com",
            "https://b.example.com/oauth2/idpresponse",
            "https://b.example.com/saml2/idpresponse",
          + "https://a.example.com/",
          + "https://a.example.com/oauth2/idpresponse",
          + "https://a.example.com/saml2/idpresponse",
        ]
```

This PR converts the callback_urls to a set to ignore ordering. 