### PR TITLE
Tweaks the provider alias so you can use module with TF 0.13+

### DIFF
--- a/terraform-modules/acm/main.tf
+++ b/terraform-modules/acm/main.tf
@@ -11,10 +11,10 @@ resource "aws_acm_certificate" "cert" {
 resource "aws_route53_record" "website_cert_validation" {
   count = length(var.domain_names)
 
-  name    = aws_acm_certificate.cert.domain_validation_options[count.index].resource_record_name
-  type    = aws_acm_certificate.cert.domain_validation_options[count.index].resource_record_type
+  name    = element(aws_acm_certificate.cert.domain_validation_options.*.resource_record_name, count.index)
+  type    = element(aws_acm_certificate.cert.domain_validation_options.*.resource_record_type, count.index)
   zone_id = var.zone_id
-  records = [aws_acm_certificate.cert.domain_validation_options[count.index].resource_record_value]
+  records = [element(aws_acm_certificate.cert.domain_validation_options.*.resource_record_value, count.index)]
   ttl     = 300
 }
 

--- a/terraform-modules/acm/versions.tf
+++ b/terraform-modules/acm/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform-modules/gsuite-saml-cognito/README.md
+++ b/terraform-modules/gsuite-saml-cognito/README.md
@@ -19,7 +19,7 @@ used with ALB's authentication support.
 - `relying_party_dns_names`: List of DNS names for all the services you'll be
   authenticating with this resource.
 
-Also requires a provider named `aws_us_east_1`, which is required for
+Also requires a provider named `aws.us-east-1`, which is required for
 provisioning an ACM certificate.
 
 ## Outputs
@@ -55,7 +55,7 @@ module "gsuite_saml_cognito" {
 
   providers = {
     aws           = aws
-    aws_us_east_1 = aws.us-east-1
+    aws.us-east-1 = aws.us-east-1
   }
 }
 ```

--- a/terraform-modules/gsuite-saml-cognito/main.tf
+++ b/terraform-modules/gsuite-saml-cognito/main.tf
@@ -44,13 +44,13 @@ resource "aws_cognito_user_pool_client" "gsuite_saml" {
 }
 
 module "auth_domain_certificate" {
-  source = "git::https://github.com/alloy-commons/alloy-open-source//terraform-modules/acm?ref=deb6608af6d026983b0b32966c3616a75e417422"
+  source = "git::https://github.com/alloy-commons/alloy-open-source//terraform-modules/acm?ref=be02d7725895d80ad7a41c37922d25c666dc649d"
 
   domain_names = [var.dns_name]
   zone_id      = var.zone_id
 
   providers = {
-    aws = aws_us_east_1
+    aws = aws.us-east-1
   }
 }
 

--- a/terraform-modules/gsuite-saml-cognito/providers.tf
+++ b/terraform-modules/gsuite-saml-cognito/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  alias = "us-east-1"
+}

--- a/terraform-modules/gsuite-saml-cognito/versions.tf
+++ b/terraform-modules/gsuite-saml-cognito/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Newer versions of terraform do not allow using `_` in the provider name/alias.

```
❯ terraform plan

Error: Invalid provider local name

  on main.tf line XX, in module "gsuite_saml_cognito":
  XX:     aws_us_east_1 = aws.us-east-1

aws_us_east_1 is an invalid provider local name: must contain only letters,
digits, and dashes, and may not use leading or trailing dashes
```

This addresses this, but also is a breaking change. Given the current pattern of ref by commit, this should still be good to go for others until such time they choose to upgrade and reference the new commit-ish.